### PR TITLE
feat: variant ごとのリサイズサイズを設定可能にする

### DIFF
--- a/example.config.json
+++ b/example.config.json
@@ -12,5 +12,12 @@
   ],
   "load_system_fonts": true,
   "webp_quality": 75.0,
-  "encode_avif": false
+  "encode_avif": false,
+  "variant_sizes": {
+    "avatar":  { "width": null, "height": 320 },
+    "emoji":   { "width": null, "height": 128 },
+    "preview": { "width": 200,  "height": 200 },
+    "badge":   { "width": 96,   "height": 96  },
+    "static":  { "width": 498,  "height": 422 }
+  }
 }

--- a/src/image_test.rs
+++ b/src/image_test.rs
@@ -56,6 +56,7 @@ fn test_config() -> std::sync::Arc<crate::ConfigFile> {
 		blocked_networks: None,
 		blocked_hosts: None,
 		max_concurrent: 64,
+		variant_sizes: crate::VariantSizes::default(),
 	})
 }
 
@@ -151,6 +152,93 @@ fn test_image_size_hint_badge_priority() {
 	let ctx = test_request_context(parms);
 	// badge is checked first
 	assert_eq!(ctx.image_size_hint(), (96, 96));
+}
+
+// --- custom variant_sizes tests ---
+
+#[cfg(test)]
+fn test_config_with_variant_sizes(vs: crate::VariantSizes) -> std::sync::Arc<crate::ConfigFile> {
+	let mut config = (*test_config()).clone();
+	config.variant_sizes = vs;
+	std::sync::Arc::new(config)
+}
+
+#[cfg(test)]
+fn test_request_context_with_config(parms: crate::RequestParams, config: std::sync::Arc<crate::ConfigFile>) -> crate::RequestContext {
+	let mut fontdb = resvg::usvg::fontdb::Database::new();
+	fontdb.load_font_source(resvg::usvg::fontdb::Source::Binary(std::sync::Arc::new(
+		include_bytes!("../asset/font/Aileron-Light.otf"),
+	)));
+	crate::RequestContext {
+		is_accept_avif: false,
+		headers: axum::http::HeaderMap::new(),
+		parms,
+		src_bytes: Vec::new(),
+		config,
+		codec: Err(None),
+		dummy_img: std::sync::Arc::new(include_bytes!("../asset/dummy.png").to_vec()),
+		fontdb: std::sync::Arc::new(fontdb),
+	}
+}
+
+#[test]
+fn test_image_size_hint_custom_badge() {
+	let vs = crate::VariantSizes {
+		badge: Some(crate::VariantSize { width: Some(64), height: Some(64) }),
+		..Default::default()
+	};
+	let mut parms = default_parms();
+	parms.badge = Some("1".to_owned());
+	let ctx = test_request_context_with_config(parms, test_config_with_variant_sizes(vs));
+	assert_eq!(ctx.image_size_hint(), (64, 64));
+}
+
+#[test]
+fn test_image_size_hint_custom_avatar_null_width() {
+	let vs = crate::VariantSizes {
+		avatar: Some(crate::VariantSize { width: None, height: Some(256) }),
+		..Default::default()
+	};
+	let mut parms = default_parms();
+	parms.avatar = Some("1".to_owned());
+	let ctx = test_request_context_with_config(parms, test_config_with_variant_sizes(vs));
+	assert_eq!(ctx.image_size_hint(), (u32::MAX, 256));
+}
+
+#[test]
+fn test_image_size_hint_custom_emoji() {
+	let vs = crate::VariantSizes {
+		emoji: Some(crate::VariantSize { width: Some(64), height: Some(64) }),
+		..Default::default()
+	};
+	let mut parms = default_parms();
+	parms.emoji = Some("1".to_owned());
+	let ctx = test_request_context_with_config(parms, test_config_with_variant_sizes(vs));
+	assert_eq!(ctx.image_size_hint(), (64, 64));
+}
+
+#[test]
+fn test_image_size_hint_custom_preview() {
+	let vs = crate::VariantSizes {
+		preview: Some(crate::VariantSize { width: Some(400), height: Some(400) }),
+		..Default::default()
+	};
+	let mut parms = default_parms();
+	parms.preview = Some("1".to_owned());
+	let ctx = test_request_context_with_config(parms, test_config_with_variant_sizes(vs));
+	assert_eq!(ctx.image_size_hint(), (400, 400));
+}
+
+#[test]
+fn test_image_size_hint_custom_static() {
+	let vs = crate::VariantSizes {
+		r#static: Some(crate::VariantSize { width: Some(1024), height: Some(768) }),
+		..Default::default()
+	};
+	let mut parms = default_parms();
+	parms.r#static = Some("1".to_owned());
+	let ctx = test_request_context_with_config(parms, test_config_with_variant_sizes(vs));
+	assert_eq!(ctx.image_size_hint(), (1024, 768));
 }
 
 // --- resize() method tests ---

--- a/src/img.rs
+++ b/src/img.rs
@@ -6,20 +6,31 @@ use crate::RequestContext;
 
 impl RequestContext{
 	pub(crate) fn image_size_hint(&self)->(u32,u32){
+		let vs=&self.config.variant_sizes;
 		if self.parms.badge.is_some(){
-			return (96,96);
+			return vs.badge.as_ref()
+				.map(|v|(v.width.unwrap_or(u32::MAX),v.height.unwrap_or(u32::MAX)))
+				.unwrap_or((96,96));
 		}
 		if self.parms.r#static.is_some(){
-			return (498,422);
+			return vs.r#static.as_ref()
+				.map(|v|(v.width.unwrap_or(u32::MAX),v.height.unwrap_or(u32::MAX)))
+				.unwrap_or((498,422));
 		}
 		if self.parms.emoji.is_some(){
-			return (u32::MAX,128);
+			return vs.emoji.as_ref()
+				.map(|v|(v.width.unwrap_or(u32::MAX),v.height.unwrap_or(u32::MAX)))
+				.unwrap_or((u32::MAX,128));
 		}
 		if self.parms.preview.is_some(){
-			return (200,200);
+			return vs.preview.as_ref()
+				.map(|v|(v.width.unwrap_or(u32::MAX),v.height.unwrap_or(u32::MAX)))
+				.unwrap_or((200,200));
 		}
 		if self.parms.avatar.is_some(){
-			return (u32::MAX,320);
+			return vs.avatar.as_ref()
+				.map(|v|(v.width.unwrap_or(u32::MAX),v.height.unwrap_or(u32::MAX)))
+				.unwrap_or((u32::MAX,320));
 		}
 		(self.config.max_pixels,self.config.max_pixels)
 	}

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,24 @@ pub struct ConfigFile{
 	blocked_hosts:Option<Vec<String>>,
 	#[serde(default="default_max_concurrent")]
 	max_concurrent:u32,
+	#[serde(default)]
+	variant_sizes:VariantSizes,
 }
 fn default_max_concurrent()->u32{ 64 }
+
+#[derive(Clone,Debug,Serialize,Deserialize)]
+pub struct VariantSize{
+	pub width:Option<u32>,
+	pub height:Option<u32>,
+}
+#[derive(Clone,Debug,Default,Serialize,Deserialize)]
+pub struct VariantSizes{
+	pub avatar:Option<VariantSize>,
+	pub emoji:Option<VariantSize>,
+	pub preview:Option<VariantSize>,
+	pub badge:Option<VariantSize>,
+	pub r#static:Option<VariantSize>,
+}
 
 /// Pre-parsed runtime config (parsed once at startup, shared via Arc)
 pub struct RuntimeConfig{
@@ -245,6 +261,7 @@ fn main() {
 			blocked_networks:None,
 			blocked_hosts:None,
 			max_concurrent:64,
+			variant_sizes:VariantSizes::default(),
 		};
 		let default_config=serde_json::to_string_pretty(&default_config).expect("serialize default config");
 		std::fs::File::create(&config_path).expect("create default config.json").write_all(default_config.as_bytes()).expect("write default config");


### PR DESCRIPTION
## Summary
- `ConfigFile` に `variant_sizes` フィールドを追加し、avatar/emoji/preview/badge/static の各 variant のリサイズサイズを `config.json` から設定可能にした
- `width`/`height` が `null` の場合は制限なし（`u32::MAX` 相当）
- `variant_sizes` 自体が省略された場合は従来のハードコード値をそのまま使用（後方互換）

## 変更ファイル
- `src/main.rs`: `VariantSize`/`VariantSizes` 構造体追加、`ConfigFile` にフィールド追加
- `src/img.rs`: `image_size_hint()` を config から読むよう変更
- `src/image_test.rs`: カスタム variant サイズのテスト追加
- `example.config.json`: `variant_sizes` セクション追加

## 設定例
```json
{
  "variant_sizes": {
    "avatar":  { "width": null, "height": 320 },
    "emoji":   { "width": null, "height": 128 },
    "preview": { "width": 200,  "height": 200 },
    "badge":   { "width": 96,   "height": 96  },
    "static":  { "width": 498,  "height": 422 }
  }
}
```

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)