### PR TITLE
chore(docker): runtime image を distroless (debian13) に移行 (#5)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -176,10 +176,14 @@ jobs:
           docker image ls -a
 
       - name: Extract Application
+        # distroless には cp / shell が無いため `docker run <image> cp` 不可。
+        # docker create + docker cp で binary を取り出す方式に変更。
         run: |
           mkdir /tmp/app/
           chmod o+rwx /tmp/app/
-          docker run --rm -t -v /tmp/app:/tmp/app ${{ github.repository }}:latest cp /media-proxy-rs/media-proxy-rs /tmp/app/
+          cid=$(docker create ${{ github.repository }}:latest)
+          docker cp "$cid:/media-proxy-rs/media-proxy-rs" /tmp/app/
+          docker rm "$cid"
 
       - name: gzip Application
         working-directory: /tmp/app

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,11 +36,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # gcr.io/distroless/static-debian13 がサポートする arch のみ。
+        # 旧マトリクスの linux/386 / linux/arm/v6 は distroless に manifest が無いため非対応。
         platform:
-          - linux/386
           - linux/amd64
           - linux/arm64
-          - linux/arm/v6
           - linux/arm/v7
           - linux/riscv64
     steps:
@@ -151,11 +151,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # gcr.io/distroless/static-debian13 がサポートする arch のみ。
         platform:
-          - linux/386
           - linux/amd64
           - linux/arm64
-          - linux/arm/v6
           - linux/arm/v7
     steps:
       - name: Prepare
@@ -207,11 +206,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # gcr.io/distroless/static-debian13 がサポートする arch のみ。
         platform:
-          - linux/386
           - linux/amd64
           - linux/arm64
-          - linux/arm/v6
           - linux/arm/v7
     steps:
       - name: Prepare

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,15 +36,31 @@ COPY asset ./asset
 COPY examples ./examples
 RUN --mount=type=cache,target=/var/cache/cargo --mount=type=cache,target=/app/target bash /app/crossfiles/build.sh
 
-FROM public.ecr.aws/docker/library/alpine:latest
-ARG UID="852"
-ARG GID="852"
-RUN addgroup -g "${GID}" proxy && adduser -u "${UID}" -G proxy -D -h /media-proxy-rs -s /bin/sh proxy
-WORKDIR /media-proxy-rs
-USER proxy
+# smoke test stage: runtime が distroless (shell なし) なのでビルド時自己テストは別ステージで実行する。
+# プラットフォーム指定なし = TARGETPLATFORM、buildx + QEMU 経由で cross-emulation される。
+FROM public.ecr.aws/docker/library/alpine:latest AS smoke_test
+WORKDIR /test
 COPY --from=build_app /app/media-proxy-rs ./media-proxy-rs
 COPY --from=build_app /app/healthcheck ./healthcheck
-RUN sh -c "MEDIA_PROXY_ALLOWED_NETWORKS=127.0.0.0/8 ./media-proxy-rs&" && ./healthcheck 12887 http://127.0.0.1:12766/test.webp
-HEALTHCHECK --interval=30s --timeout=3s CMD ./healthcheck 5555 http://127.0.0.1:12766/test.webp || exit 1
+RUN sh -c "MEDIA_PROXY_ALLOWED_NETWORKS=127.0.0.0/8 ./media-proxy-rs&" && ./healthcheck 12887 http://127.0.0.1:12766/test.webp && touch /test/passed
+
+# runtime stage 用の rootfs を 852 所有でステージングする (distroless には mkdir/chown が無く、
+# COPY の --chown も dest dir auto-create には効かないため、build stage で完全な階層構造を組む)。
+# original alpine 版で adduser -h /media-proxy-rs が果たしていた役割と同じ。
+FROM --platform=$BUILDPLATFORM cross_build AS runtime_home
+RUN mkdir -p /rootfs/media-proxy-rs
+COPY --from=build_app /app/media-proxy-rs /rootfs/media-proxy-rs/media-proxy-rs
+COPY --from=build_app /app/healthcheck /rootfs/media-proxy-rs/healthcheck
+RUN chown -R 852:852 /rootfs/media-proxy-rs && chmod 755 /rootfs/media-proxy-rs/media-proxy-rs /rootfs/media-proxy-rs/healthcheck
+
+# runtime: gcr.io/distroless/static-debian13 (CA certs + tzdata + libc-stub のみ、約 2MB)
+FROM gcr.io/distroless/static-debian13:latest
+# rootfs まるごと / に展開すると /media-proxy-rs ディレクトリの ownership (852:852) も保持される
+COPY --from=runtime_home /rootfs/ /
+# smoke test stage の成果物を取り込むことでテスト失敗時にビルドを失敗させる
+COPY --from=smoke_test /test/passed /etc/smoke-passed
+WORKDIR /media-proxy-rs
+USER 852:852
+HEALTHCHECK --interval=30s --timeout=3s CMD ["./healthcheck", "5555", "http://127.0.0.1:12766/test.webp"]
 EXPOSE 12766
 CMD ["./media-proxy-rs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,13 @@ RUN --mount=type=cache,target=/var/cache/cargo --mount=type=cache,target=/app/ta
 
 # smoke test stage: runtime が distroless (shell なし) なのでビルド時自己テストは別ステージで実行する。
 # プラットフォーム指定なし = TARGETPLATFORM、buildx + QEMU 経由で cross-emulation される。
+# original Dockerfile と同じ UID 852 で実行することで本番稼働 UID とテスト UID の整合を保つ。
 FROM public.ecr.aws/docker/library/alpine:latest AS smoke_test
+RUN addgroup -g 852 proxy && adduser -u 852 -G proxy -D -h /test proxy
 WORKDIR /test
-COPY --from=build_app /app/media-proxy-rs ./media-proxy-rs
-COPY --from=build_app /app/healthcheck ./healthcheck
+COPY --from=build_app --chown=852:852 /app/media-proxy-rs ./media-proxy-rs
+COPY --from=build_app --chown=852:852 /app/healthcheck ./healthcheck
+USER 852:852
 RUN sh -c "MEDIA_PROXY_ALLOWED_NETWORKS=127.0.0.0/8 ./media-proxy-rs&" && ./healthcheck 12887 http://127.0.0.1:12766/test.webp && touch /test/passed
 
 # runtime stage 用の rootfs を 852 所有でステージングする (distroless には mkdir/chown が無く、

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ chmod u+x ./media-proxy-rs
 ```
 利用するプラットフォームに応じて適切なバイナリを選択してください。ファイル名のリストを示します
 ```
-media-proxy-rs_linux-386.gz (i686+sse2)
 media-proxy-rs_linux-amd64.gz (x86-64-v3)
-media-proxy-rs_linux-arm-v6.gz
 media-proxy-rs_linux-arm-v7.gz
 media-proxy-rs_linux-arm64.gz
 media-proxy-rs_linux-riscv64.gz
 ```
+
+> Docker イメージは `gcr.io/distroless/static-debian13` ベースに移行したため、shell や `docker exec sh` が使えません。トラブル時はファイルシステム確認に `docker create <image> && docker export <cid> | tar -tvf -` などを利用してください。
 
 ## 設定ファイル
 環境変数`MEDIA_PROXY_CONFIG_PATH`を設定する事でファイルの場所を指定できます  
@@ -81,9 +81,9 @@ media-proxy-rs_linux-riscv64.gz
 - [x] x86_64-unknown-linux-musl
 - [x] aarch64-unknown-linux-musl
 - [x] armv7-unknown-linux-musleabihf
-- [x] arm-unknown-linux-musleabihf
-- [x] i686-unknown-linux-musl
 - [x] riscv64gc-unknown-linux-musl
+
+(Docker runtime base が distroless/static-debian13 になったため、`i686-unknown-linux-musl` / `arm-unknown-linux-musleabihf` のターゲットは Docker イメージとしては配布していません)
 
 ## ビルド(x64 Docker)
 Dockerを使用する場合はbuildxとqemuによるクロスコンパイルが利用できます  


### PR DESCRIPTION
Closes #5

## 概要

runtime base を alpine から `gcr.io/distroless/static-debian13` に変更し、shell / パッケージマネージャ / busybox を完全に排除。バイナリは既に musl 静的リンクなので distroless との相性は完璧。

## 構成

```
build_app (musl static) → runtime_home (rootfs を 852:852 で staging)
                       ↘ smoke_test (alpine) ← runtime に成果物 COPY で実行強制
                       ↘ runtime (distroless/static-debian13) ← rootfs を / に展開
```

## 主な変更

- alpine 側で adduser していたものを runtime_home stage で `/rootfs/media-proxy-rs` を 852:852 所有で組み立て、distroless に `COPY --from=runtime_home /rootfs/ /` で展開する方式に
- runtime 内 self-test (`RUN sh -c "./media-proxy-rs&" && ./healthcheck`) は shell 必須なので `smoke_test` stage に分離。`COPY --from=smoke_test /test/passed /etc/smoke-passed` で必ずテストが走るよう強制
- `HEALTHCHECK` を exec 形式 (`CMD ["./healthcheck", ...]`) に変更 (shell-form は distroless で動かない)
- USER 852:852 を維持 (既存 volume との互換性)

## 検証

- `docker build .` → 通過
- bare `docker run -d -e MEDIA_PROXY_ALLOWED_NETWORKS=127.0.0.0/8 media-proxy-rs:distroless-test` → `Listening on tcp://0.0.0.0:12766` 出力、bind/起動 OK
- `docker exec <cid> /media-proxy-rs/healthcheck 5555 http://127.0.0.1:12766/test.webp` → `ok` (rc=0)
- イメージサイズ: **56.5MB → 49.5MB (-7MB)**、shared layer **16.1MB → 12.9MB**
- `/media-proxy-rs/` ディレクトリ ownership: `852:852` (volume mount との互換性維持)

## デバッグ手順 (READMEに追記想定)

distroless にはシェルが無いため `docker exec sh` 不可。トラブル時は以下のいずれか:

```bash
# debug variant に一時切替 (busybox 入り)
docker run --rm -it --entrypoint=sh ghcr.io/nekonoverse/media-proxy-rs:debug

# または既存 image の filesystem を tar でダンプ
docker create --name inspect <image> && docker export inspect | tar -tvf -
```

## Test plan

- [ ] CI build 通過
- [ ] PR マージ後 ghcr の `:main` タグで pull → 起動確認
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/media-proxy-rs/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->